### PR TITLE
Fix crash if UDP scanner cannot resolve DNS name

### DIFF
--- a/scanner/udp.go
+++ b/scanner/udp.go
@@ -47,7 +47,10 @@ func UDPProtoScan(target string, port uint32, config UDPScanner) (*PortscanResul
 	if err != nil && strings.Contains(err.Error(), "socket: too many open files") {
 		return nil, fmt.Errorf("Too many open files. You are running too many scan workers and the OS is limiting file descriptors. YOU ARE MISSING SCAN RESULTS. Scan with less workers")
 	}
-	utils.CheckError(err, false)
+	if err != nil {
+		utils.CheckError(err, false)
+		return nil, nil
+	}
 	defer conn.Close()
 	// This is the real timeout that is applied. We send a packet and wait for a response or receive an error in case of timeout
 	conn.SetDeadline(time.Now().Add(config.timeout))


### PR DESCRIPTION
When resolving the DNS name of a target fails, the nray node crashes.

Please review the fix, I wrote it during a pentest to continue the scanning ;)